### PR TITLE
[SHOTS-10673] revert parallelization due to breaking errors in upstream test suites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
-  "name": "middleware-container",
-  "version": "0.2.0",
+  "name": "@boxed/middleware-container",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "middleware-container",
-      "version": "0.2.0",
+      "name": "@boxed/middleware-container",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "async.parallel": "0.5.2",
         "boxed-injector": "2.0.0",
         "connect": "3.7.0"
       },
@@ -1032,94 +1031,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/async.eachof": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.eachof/-/async.eachof-0.5.2.tgz",
-      "integrity": "sha512-MbyBBO+flXC5Tk4b5IVNBUVJzirIEYOnQn3g7VVfmfu6hpXxr498df9RYpQ5noXad+5c/OzmZ/bXboMJw4Qm7w==",
-      "license": "MIT",
-      "dependencies": {
-        "async.util.keyiterator": "0.5.2",
-        "async.util.noop": "0.5.2",
-        "async.util.once": "0.5.2",
-        "async.util.onlyonce": "0.5.2"
-      }
-    },
-    "node_modules/async.parallel": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.parallel/-/async.parallel-0.5.2.tgz",
-      "integrity": "sha512-F8R7aZsOiHkm+AbhxYlFKNjQu+aM2YsnJrS/i/xY6yFTVXU4fhQcBJpBcchkZ69tHvnbObGoJflbb+Rzm23yNw==",
-      "license": "MIT",
-      "dependencies": {
-        "async.eachof": "0.5.2",
-        "async.util.parallel": "0.5.2"
-      }
-    },
-    "node_modules/async.util.isarray": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.isarray/-/async.util.isarray-0.5.2.tgz",
-      "integrity": "sha512-wbUzlrwON8RUgi+v/rhF0U99Ce8Osjcn+JP/mFNg6ymvShcobAOvE6cvLajSY5dPqKCOE1xfdhefgBif11zZgw==",
-      "license": "MIT"
-    },
-    "node_modules/async.util.isarraylike": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.isarraylike/-/async.util.isarraylike-0.5.2.tgz",
-      "integrity": "sha512-DbFpsz3ZFNkohAW8IpGTlm8gotU32zpqe3Y2XkEA/G3XNO6rmUTKPpo7XgXUruoI+AsGi8+0zWpJHe7t1sLiAg==",
-      "license": "MIT",
-      "dependencies": {
-        "async.util.isarray": "0.5.2"
-      }
-    },
-    "node_modules/async.util.keyiterator": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.keyiterator/-/async.util.keyiterator-0.5.2.tgz",
-      "integrity": "sha512-cktrETawCwgu13y3KZs2uMGFnNHc+IjKPZsavtRaoCjLELkePb2co4zrr+ghPvEqLXZIJPTKqC2HFZgJTssMVw==",
-      "license": "MIT",
-      "dependencies": {
-        "async.util.isarraylike": "0.5.2",
-        "async.util.keys": "0.5.2"
-      }
-    },
-    "node_modules/async.util.keys": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.keys/-/async.util.keys-0.5.2.tgz",
-      "integrity": "sha512-umCOCRCRYwIC2Ho3fbuhKwIIe7OhQsVoVKGoF5GoQiGJUmjP4TG0Bmmcdpm7yW/znoIGKpnjKzVQz0niH4tfqw==",
-      "license": "MIT"
-    },
-    "node_modules/async.util.noop": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.noop/-/async.util.noop-0.5.2.tgz",
-      "integrity": "sha512-AdwShXwE0KoskgqVJAck8zcM32nIHj3AC8ZN62ZaR5srhrY235Nw18vOJZWxcOfhxdVM0hRVKM8kMx7lcl7cCQ==",
-      "license": "MIT"
-    },
-    "node_modules/async.util.once": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.once/-/async.util.once-0.5.2.tgz",
-      "integrity": "sha512-YQ5WPzDTt2jlblUDkq2I5RV/KiAJErJ4/0cEFhYPaZzqIuF/xDzdGvnEKe7UeuoMszsVPeajzcpKgkbwdb9MUA==",
-      "license": "MIT"
-    },
-    "node_modules/async.util.onlyonce": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.onlyonce/-/async.util.onlyonce-0.5.2.tgz",
-      "integrity": "sha512-UgQvkU9JZ+I0Cm1f56XyGXcII+J3d/5XWUuHpcevlItuA3WFSJcqZrsyAUck2FkRSD8BwYQX1zUTDp3SJMVESg==",
-      "license": "MIT"
-    },
-    "node_modules/async.util.parallel": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.parallel/-/async.util.parallel-0.5.2.tgz",
-      "integrity": "sha512-0bEvwmQ8fxsTYNwacw5iq0i3PvGryRkXxZ01Rvox21izdMdls9IH2rAZjfunbgI8j6nFRyIdCmMINQ9kka99ow==",
-      "license": "MIT",
-      "dependencies": {
-        "async.util.isarraylike": "0.5.2",
-        "async.util.noop": "0.5.2",
-        "async.util.restparam": "0.5.2"
-      }
-    },
-    "node_modules/async.util.restparam": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.restparam/-/async.util.restparam-0.5.2.tgz",
-      "integrity": "sha512-Q9Z+zgmtMxFX5i7CnBvNOkgrL5hptztCqwarQluyNudUUk4iCmyjmsQl8MuQEjNh3gGqP5ayvDaextL1VXXgIg==",
-      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxed/middleware-container",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Middleware Chaining & Dependency Resolution",
   "author": {
     "name": "Spresso Engineering",
@@ -47,7 +47,6 @@
     "lint": "eslint ./src --ext .ts --quiet"
   },
   "dependencies": {
-    "async.parallel": "0.5.2",
     "boxed-injector": "2.0.0",
     "connect": "3.7.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import { Injector } from "boxed-injector";
 import connect from "connect";
-import parallel from "async.parallel";
-import { RequestHandler } from "express";
 
 const handler: ProxyHandler<Injector> = {
   get(target, propKey) {
@@ -19,48 +17,14 @@ const handler: ProxyHandler<Injector> = {
       const dep: string | string[] = args[0];
 
       // get the dependency graph
-      const graph = target.graph(dep);
-      // console.log(graph);
-
-      const [parallelizable, sequential] = graph.reduce(
-        (groups, middleware) => {
-          const [parallelizable, sequential] = groups;
-          // @ts-ignore
-          const dependencies = target.instances?.[middleware]?.depends ?? [];
-          if (dependencies.length > 0) {
-            sequential.push(middleware);
-          } else {
-            parallelizable.push(middleware);
-          }
-          return groups;
-        },
-        [[], []] as Readonly<[string[], string[]]>
-      );
-
-      const parallelMiddleware = parallelizable.map((mw) => target.get(mw));
-      const combinedParallelizable: RequestHandler = (req, res, next) => {
-        const asyncFns = parallelMiddleware.map(
-          (mw) => (next) => mw(req, res, next)
-        );
-        return parallel(asyncFns, next);
-      };
-
-      const middleware = connect();
-
-      if (parallelizable.length) {
-        // console.log('paralellizing middlewares: ', parallelizable);
-        middleware.use(combinedParallelizable);
-      }
-
-      // console.log('sequencing middlewares: ', sequential);
-
       return (
-        sequential
+        target
+          .graph(dep)
           // create a chained connect which combines all of the middlewares
           .reduce((chain, middleware) => {
             chain.use(target.get(middleware));
             return chain;
-          }, middleware)
+          }, connect())
       );
     };
   },


### PR DESCRIPTION
revert parallelization changes from earlier PR. It looks like we never cut over to using the newer version of this package and it was never published. SFG is still on 0.1.0.

`async.parallel` package is 9 years old and abandoned anyway. YAGNI

Published 0.4.0 following merge