### PR TITLE
SHOTS-10940: Provide named export for ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@boxed/middleware-container",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@boxed/middleware-container",
-      "version": "0.3.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "boxed-injector": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxed/middleware-container",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Middleware Chaining & Dependency Resolution",
   "author": {
     "name": "Spresso Engineering",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
-import { Injector } from "boxed-injector";
-import connect from "connect";
+import { Injector } from 'boxed-injector';
+import connect from 'connect';
 
 const handler: ProxyHandler<Injector> = {
   get(target, propKey) {
-    if (propKey === "__target") {
+    if (propKey === '__target') {
       return target;
     }
-    if (typeof target[propKey] !== "function") {
+    if (typeof target[propKey] !== 'function') {
       return target[propKey];
     }
     return function (...args) {
-      if (propKey !== "get") {
+      if (propKey !== 'get') {
         return target[propKey].apply(this, args);
       }
 
@@ -28,6 +28,11 @@ const handler: ProxyHandler<Injector> = {
       );
     };
   },
+};
+
+export const init = () => {
+  const injector = new Injector();
+  return new Proxy(injector, handler);
 };
 
 export default function () {


### PR DESCRIPTION
Provide named export for ESM

ESM does not work well with export default function (suspect related to usage of Proxy in conjunction with export default function) - current version of @boxed/middleware-container would require us to do middleware.default.default().